### PR TITLE
BREAKCHANGE: Support multi leaves proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Cargo.lock
 target/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 
 A generalized merkle mountain range implementation.
 
+**Notice** this library is not stable yet, API and proof format may changes. Make sure you know what you do before using this library.
+
+## Features
+
+* Leaves accumulation
+* Multi leaves merkle proof
+* Accumulate from last leaf's merkle proof
+
 ## Construct
 
 ``` txt

--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -65,7 +65,7 @@ fn bench(c: &mut Criterion) {
         let (mmr_size, store, positions) = prepare_mmr(100_0000);
         let mmr = MMR::<_, MergeNumberHash, _>::new(mmr_size, &store);
         let mut rng = thread_rng();
-        b.iter(|| mmr.gen_proof(*positions.choose(&mut rng).unwrap()));
+        b.iter(|| mmr.gen_proof(vec![*positions.choose(&mut rng).unwrap()]));
     });
 
     c.bench_function("MMR verify", |b| {
@@ -77,13 +77,15 @@ fn bench(c: &mut Criterion) {
             .map(|_| {
                 let pos = positions.choose(&mut rng).unwrap();
                 let elem = (&store).get_elem(*pos).unwrap().unwrap();
-                let proof = mmr.gen_proof(*pos).unwrap();
+                let proof = mmr.gen_proof(vec![*pos]).unwrap();
                 (pos, elem, proof)
             })
             .collect();
         b.iter(|| {
             let (pos, elem, proof) = proofs.choose(&mut rng).unwrap();
-            proof.verify(root.clone(), **pos, elem.clone()).unwrap();
+            proof
+                .verify(root.clone(), vec![(**pos, elem.clone())])
+                .unwrap();
         });
     });
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,10 @@ pub enum Error {
     GetRootOnEmpty,
     InconsistentStore,
     StoreError(crate::string::String),
+    /// proof items is not enough to build a tree
+    CorruptedProof,
+    /// The leaves is an empty list, or beyond the mmr range
+    GenProofForInvalidLeaves,
 }
 
 impl core::fmt::Display for Error {
@@ -14,6 +18,8 @@ impl core::fmt::Display for Error {
             GetRootOnEmpty => write!(f, "Get root on an empty MMR")?,
             InconsistentStore => write!(f, "Inconsistent store")?,
             StoreError(msg) => write!(f, "Store error {}", msg)?,
+            CorruptedProof => write!(f, "Corrupted proof")?,
+            GenProofForInvalidLeaves => write!(f, "Generate proof ofr invalid leaves")?,
         }
         Ok(())
     }

--- a/src/tests/test_accumulate_headers.rs
+++ b/src/tests/test_accumulate_headers.rs
@@ -156,7 +156,7 @@ impl Prover {
             mmr.get_root()?.serialize(),
             self.headers[later_number as usize].0.chain_root
         );
-        mmr.gen_proof(pos)
+        mmr.gen_proof(vec![pos])
     }
 
     fn get_pos(&self, number: u64) -> u64 {
@@ -188,6 +188,6 @@ fn test_insert_header() {
     let pos = leaf_index_to_pos(h1);
     assert_eq!(pos, prover.get_pos(h1));
     assert_eq!(prove_elem, (&prover.store).get_elem(pos).unwrap().unwrap());
-    let result = proof.verify(root, pos, prove_elem).expect("verify");
+    let result = proof.verify(root, vec![(pos, prove_elem)]).expect("verify");
     assert!(result);
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -71,8 +71,8 @@ impl<T: Clone + Debug + PartialEq, M: Merge<Item = T>> MemMMR<T, M> {
         Ok(pos)
     }
 
-    pub fn gen_proof(&self, pos: u64) -> Result<MerkleProof<T, M>> {
+    pub fn gen_proof(&self, pos_list: Vec<u64>) -> Result<MerkleProof<T, M>> {
         let mmr = MMR::<T, M, &MemStore<T>>::new(self.mmr_size, &self.store);
-        mmr.gen_proof(pos)
+        mmr.gen_proof(pos_list)
     }
 }


### PR DESCRIPTION
1. Support multi leaves merkle proof
2. Unfortunately, the proof format is changed, which means the proofs generated by the previous version are broken with this new version, verify function will return `CorruptedProof` error or return an incorrect root.