### PR TITLE
[BREAK CHANGE] Optimize merkle proof layout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-merkle-mountain-range"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Use a queue to verify proof from bottom to top, this refactor reduces the complexity of generating and verification merkle proof.

This is an incompatible change, proof generated by an old/new version, can not be verified in the new/old version.