### PR TITLE
Public `helper`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod error;
-mod helper;
+pub mod helper;
 mod merge;
 mod mmr;
 mod mmr_store;


### PR DESCRIPTION
The helper fn(s) are really useful. So public it.

For example, we use `helper::get_peaks()` to perform the nodes pruning.