### PR TITLE
feat: add a trait method to control how to merge peaks

### DIFF
--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,4 +1,9 @@
 pub trait Merge {
     type Item;
+
     fn merge(left: &Self::Item, right: &Self::Item) -> Self::Item;
+
+    fn merge_peaks(peak1: &Self::Item, peak2: &Self::Item) -> Self::Item {
+        Self::merge(peak1, peak2)
+    }
 }

--- a/src/mmr.rs
+++ b/src/mmr.rs
@@ -96,7 +96,7 @@ impl<'a, T: Clone + PartialEq + Debug, M: Merge<Item = T>, S: MMRStore<T>> MMR<T
         while rhs_peaks.len() > 1 {
             let right_peak = rhs_peaks.pop().expect("pop");
             let left_peak = rhs_peaks.pop().expect("pop");
-            rhs_peaks.push(M::merge(&right_peak, &left_peak));
+            rhs_peaks.push(M::merge_peaks(&right_peak, &left_peak));
         }
         Ok(rhs_peaks.pop())
     }
@@ -394,7 +394,7 @@ fn bagging_peaks_hashes<'a, T: 'a + PartialEq + Debug + Clone, M: Merge<Item = T
     while peaks_hashes.len() > 1 {
         let right_peak = peaks_hashes.pop().expect("pop");
         let left_peak = peaks_hashes.pop().expect("pop");
-        peaks_hashes.push(M::merge(&right_peak, &left_peak));
+        peaks_hashes.push(M::merge_peaks(&right_peak, &left_peak));
     }
     peaks_hashes.pop().ok_or(Error::CorruptedProof)
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 mod test_accumulate_headers;
 mod test_helper;
 mod test_mmr;
+mod test_sequence;
 
 use crate::Merge;
 use blake2b_rs::{Blake2b, Blake2bBuilder};

--- a/src/tests/test_sequence.rs
+++ b/src/tests/test_sequence.rs
@@ -1,0 +1,98 @@
+use std::fmt;
+
+use proptest::proptest;
+use rand::{prelude::*, thread_rng};
+
+use crate::{util::MemStore, Merge, MMR};
+
+#[derive(Eq, PartialEq, Clone, Default)]
+struct NumberRange {
+    start: u32,
+    end: u32,
+}
+
+struct MergeNumberRange;
+
+impl fmt::Debug for NumberRange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NumberRange({}, {})", self.start, self.end)
+    }
+}
+
+impl fmt::Debug for MergeNumberRange {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "MergeNumberRange")
+    }
+}
+
+impl From<u32> for NumberRange {
+    fn from(num: u32) -> Self {
+        Self {
+            start: num,
+            end: num,
+        }
+    }
+}
+
+impl NumberRange {
+    fn is_normalized(&self) -> bool {
+        self.start <= self.end
+    }
+}
+
+impl Merge for MergeNumberRange {
+    type Item = NumberRange;
+    fn merge(lhs: &Self::Item, rhs: &Self::Item) -> Self::Item {
+        Self::Item {
+            start: lhs.start,
+            end: rhs.end,
+        }
+    }
+    fn merge_peaks(lhs: &Self::Item, rhs: &Self::Item) -> Self::Item {
+        Self::merge(rhs, lhs)
+    }
+}
+
+fn test_sequence_sub_func(count: u32, proof_elem: Vec<u32>) {
+    let store = MemStore::default();
+    let mut mmr = MMR::<_, MergeNumberRange, _>::new(0, &store);
+    let positions = (0..count)
+        .map(|i| mmr.push(NumberRange::from(i)).expect("push"))
+        .collect::<Vec<_>>();
+    let root = mmr.get_root().expect("get_root");
+    assert!(root.is_normalized());
+    let proof = mmr
+        .gen_proof(
+            proof_elem
+                .iter()
+                .map(|elem| positions[*elem as usize])
+                .collect(),
+        )
+        .expect("gen_proof");
+    for item in proof.proof_items() {
+        assert!(item.is_normalized())
+    }
+    mmr.commit().expect("commit");
+    let result = proof
+        .verify(
+            root,
+            proof_elem
+                .iter()
+                .map(|elem| (positions[*elem as usize], NumberRange::from(*elem)))
+                .collect(),
+        )
+        .expect("verify");
+    assert!(result);
+}
+
+proptest! {
+    #[test]
+    fn test_sequence(count in 10u32..500u32) {
+        let mut leaves: Vec<u32> = (0..count).collect();
+        let mut rng = thread_rng();
+        leaves.shuffle(&mut rng);
+        let leaves_count = rng.gen_range(1, count - 1);
+        leaves.truncate(leaves_count as usize);
+        test_sequence_sub_func(count, leaves);
+    }
+}


### PR DESCRIPTION
### Proposal

Add a trait method to control how to merge peaks, in order to keep the internal order for merged nodes.

Let me show an example:

- If we have a tree who's all leaves are number ranges.

  ```rust
  struct Leaf { start: u32, end: u32 }
  ```

- When we merge two leaves, we merge the ranges.

  ```rust
  let new = left.merge(right);
  assert!(new.start == left.start);
  assert!(new.end == right.end);
  ```

- Then we can check if a node is valid with the check of the internal range.

  ```rust
  assert!(node.start <= node.end);
  ```

- But, in current implementation, the order of root nodes are changed when the count of leaves is not a power of two.

  Because

  - The peaks are merged from **RIGHT TO LEFT**.

    https://github.com/nervosnetwork/merkle-mountain-range/blob/09092d00397ee7e49c070673db8e7f21b21f41e8/src/mmr.rs#L96-L101

  - The nodes are merged from **LEFT TO RIGHT**.

    https://github.com/nervosnetwork/merkle-mountain-range/blob/09092d00397ee7e49c070673db8e7f21b21f41e8/src/mmr.rs#L64-L67

### References

- `Grin`

  - `Grin` scans the peaks from **RIGHT TO LEFT** and merges them from **LEFT TO RIGHT**.

    [Click this link to jump to the code.](https://github.com/mimblewimble/grin/blob/78c9794d30c21d40a24f255c411e04f3eab5d512/core/src/core/pmmr/pmmr.rs#L120-L125)

  - [`Grin`'s document](https://github.com/mimblewimble/grin/blob/145d81944588ff4a1b4edfba8cb2cd02cec74de1/doc/mmr.md#hashing-and-bagging) said:

    > Finally, once all the positions of the peaks are known, "bagging" the peaks consists of hashing them iteratively from the right, using the total size of the MMR as prefix. For a MMR of size N with 3 peaks p1, p2 and p3 we get the final top peak:
    > 
    > ```
    > P = Blake2b(N | Blake2b(N | Node(p3) | Node(p2)) | Node(p1))
    > ```

    I think this paragraph means that `p1, p2, p3` are "iteratively from the right", then merge thems from left to right as `Blake2b(N | Node(p3) | Node(p2)) | Node(p1)`.

- `Zcash`
  - `Zcash` scans the peaks from **RIGHT TO LEFT** for equal-sized subtrees and merges them from **LEFT TO RIGHT**.

    [Click this link to jump to the code.](https://github.com/zcash/librustzcash/blob/c423167b30f7b7afeeabe09ae5abceb49ce7d06e/zcash_history/src/tree.rs#L148-L160)

  - `Zcash` scans the peaks from **LEFT TO RIGHT** for unequal-sized subtrees and merges them from **LEFT TO RIGHT**.

    [Click this link to jump to the code.](https://github.com/zcash/librustzcash/blob/c423167b30f7b7afeeabe09ae5abceb49ce7d06e/zcash_history/src/tree.rs#L178-L185)

- `Tari` scans the peaks from **RIGHT TO LEFT** and merges them from **LEFT TO RIGHT**.

  [Click this link to jump to the code.](https://github.com/tari-project/tari/blob/ddd45f6442a6d06e2e3f53642d5fbeeac933d03c/base_layer/mmr/src/merkle_mountain_range.rs#L194)

- `Substrate` uses `ckb-merkle-mountain-range=0.3.2` directly.

  [Click this link to jump to the code.](https://github.com/paritytech/substrate/blob/77c15d2546276a865b6e8f1c5d4b1d0ec1961e72/frame/merkle-mountain-range/Cargo.toml#L17)

  So it scans the peaks from **RIGHT TO LEFT**, then it merges them from **RIGHT TO LEFT**.

### In the Further

In this PR, I kept the logic that to scan the peaks from **RIGHT TO LEFT**.

Is it the same to scan the peaks from **LEFT TO RIGHT**?

IMHO, I think the answer is "NO" for some conditions.

See the examples:

-  Scan the peaks from **RIGHT TO LEFT** and merge them from **LEFT TO RIGHT**.

  ```rust
      fn bag_rhs_peaks(&self, mut rhs_peaks: Vec<T>) -> Result<Option<T>> {
          while rhs_peaks.len() > 1 {
              let right_peak = rhs_peaks.pop().expect("pop");
              let left_peak = rhs_peaks.pop().expect("pop");
              rhs_peaks.push(M::merge(&left_peak, &right_peak));
          }
          Ok(rhs_peaks.pop())
      }
  ```

-  Scan the peaks from **LEFT TO RIGHT** and merge them from **LEFT TO RIGHT**.

  ```rust
      fn bag_rhs_peaks(&self, rhs_peaks: Vec<T>) -> Result<Option<T>> {
          let mut rhs_peaks = rhs_peaks.rev();
          while rhs_peaks.len() > 1 {
              let left_peak = rhs_peaks.pop().expect("pop");
              let right_peak = rhs_peaks.pop().expect("pop");
              rhs_peaks.push(M::merge(&left_peak, &right_peak));
          }
          Ok(rhs_peaks.pop())
      }
  ```