### PR TITLE
chore: bump version to v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-merkle-mountain-range"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Since the APIs was changed after #16, bump the minor version.