### PR TITLE
chore: remove trait bounds on struct

### DIFF
--- a/src/mmr.rs
+++ b/src/mmr.rs
@@ -15,7 +15,7 @@ use core::fmt::Debug;
 use core::marker::PhantomData;
 
 #[allow(clippy::upper_case_acronyms)]
-pub struct MMR<T, M, S: MMRStore<T>> {
+pub struct MMR<T, M, S> {
     mmr_size: u64,
     batch: MMRBatch<T, S>,
     merge: PhantomData<M>,

--- a/src/mmr_store.rs
+++ b/src/mmr_store.rs
@@ -1,7 +1,7 @@
 use crate::{vec::Vec, Result};
 
 #[derive(Default)]
-pub struct MMRBatch<Elem, Store: MMRStore<Elem>> {
+pub struct MMRBatch<Elem, Store> {
     memory_batch: Vec<(u64, Vec<Elem>)>,
     store: Store,
 }


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/issues/1689

Traits are for behavior.  Vote for this.