### PR TITLE
chore: bump version to v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-merkle-mountain-range"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 A generalized merkle mountain range implementation.
 
-**Notice** this library is not stable yet, API and proof format may changes. Make sure you know what you do before using this library.
-
 ## Features
 
 * Leaves accumulation


### PR DESCRIPTION
Since a struct was changed after #19 and the notice is removed, bump the minor version.