### PR TITLE
fix: grammar, typos and mistakes in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ A generalized merkle mountain range implementation.
 ```
 
 In MMR, we use the insertion order to reference leaves and nodes.
-we inserting a new leaf to MMR by the following:
+
+We insert a new leaf to MMR by the following:
 
 1. insert leaf or node to next position.
 2. if the current position has a left sibling, we merge the left and right nodes to produce a new parent node, then go back to step 1 to insert the node.
@@ -34,9 +35,9 @@ For example, we insert a leaf to the example MMR:
 1. insert leaf to next position: `19`.
 2. now check the left sibling `18` and calculate parent node: `merge(mmr[18], mmr[19])`.
 3. insert parent node to position `20`.
-4. the node `20` also has a left sibling `17`, calculate parent node: `merge(mmr[17], mmr[20])`.
+4. since the node `20` also has a left sibling `17`, calculate parent node: `merge(mmr[17], mmr[20])`.
 5. insert new node to next position `21`.
-6. the node `21` have no left sibling, complete the insertion.
+6. since the node `21` have no left sibling, complete the insertion.
 
 Example MMR after insertion of a new leaf:
 
@@ -54,7 +55,7 @@ Example MMR after insertion of a new leaf:
 
 An MMR is constructed by one or more sub merkle trees (or mountains). Each sub merkle tree's root is a peak in MMR, we calculate the MMR root by bagging these peaks from right to left.
 
-For example, in the 11 leaf MMR we have 3 peaks: `14, 17, 18`, we bag thses peaks from right to left to get the root: `merge(merge(mmr[18], mmr[17]), mmr[14])`.
+For example, in the 11 leaf MMR we have 3 peaks: `14, 17, 18`, we bag these peaks from right to left to get the root: `merge(mmr[14], merge(mmr[17], mmr[18]))`.
 
 ## Merkle proof
 
@@ -64,7 +65,7 @@ The merkle proof is an array of hashes constructed with the following parts:
 2. A hash that bags all right-hand side peaks, skip this part if no right-hand peaks.
 3. Hashes of all left-hand peaks from right to left, skip this part if no left-hand peaks.
 
-We can reconstruct the merkle root from the proofs. Pre calculating the peak positions from the size of MMR may help us do the bagging.
+We can reconstruct the merkle root from the proofs. Pre-calculating the peak positions from the size of MMR may help us do the bagging.
 
 ## References
 


### PR DESCRIPTION
### Mistakes in the README.md

- With the default implement, the MMR always bags peaks from right to left.

  https://github.com/nervosnetwork/merkle-mountain-range/blob/be4f439efdc76b63a306aae064538093868e00ec/src/mmr.rs#L99
  https://github.com/nervosnetwork/merkle-mountain-range/blob/be4f439efdc76b63a306aae064538093868e00ec/src/mmr.rs#L397

  Ref: #15