### PR TITLE
chore: bump version to v0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-merkle-mountain-range"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -16,12 +16,12 @@ cfg-if = "1.0"
 
 [dev-dependencies]
 faster-hex = "0.6.1"
-criterion = "0.3"
+criterion = "0.4.0"
 rand = "0.8.5"
 proptest = "1.0.0"
-lazy_static = "1.3.0"
-bytes = "1.2.0"
-blake2b-rs = "0.1.4"
+lazy_static = "1.4.0"
+bytes = "1.2.1"
+blake2b-rs = "0.2.0"
 
 [[bench]]
 name = "mmr_benchmark"

--- a/src/mmr.rs
+++ b/src/mmr.rs
@@ -21,7 +21,7 @@ pub struct MMR<T, M, S> {
     merge: PhantomData<M>,
 }
 
-impl<'a, T: Clone + PartialEq + Debug, M: Merge<Item = T>, S: MMRStore<T>> MMR<T, M, S> {
+impl<T: Clone + PartialEq + Debug, M: Merge<Item = T>, S: MMRStore<T>> MMR<T, M, S> {
     pub fn new(mmr_size: u64, store: S) -> Self {
         MMR {
             mmr_size,


### PR DESCRIPTION
- chore(deps): bump all dependencies to their latest versions
- chore: fix a clippy error