### PR TITLE
refactor: split MMRStore trait

### DIFF
--- a/benches/mmr_benchmark.rs
+++ b/benches/mmr_benchmark.rs
@@ -4,7 +4,7 @@ extern crate criterion;
 use criterion::{BenchmarkId, Criterion};
 
 use bytes::Bytes;
-use ckb_merkle_mountain_range::{util::MemStore, Error, MMRStore, Merge, Result, MMR};
+use ckb_merkle_mountain_range::{util::MemStore, Error, MMRStoreReadOps, Merge, Result, MMR};
 use rand::{seq::SliceRandom, thread_rng};
 use std::convert::TryFrom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use error::{Error, Result};
 pub use helper::{leaf_index_to_mmr_size, leaf_index_to_pos};
 pub use merge::Merge;
 pub use mmr::{MerkleProof, MMR};
-pub use mmr_store::MMRStore;
+pub use mmr_store::{MMRStoreReadOps, MMRStoreWriteOps};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "std")] {

--- a/src/tests/test_accumulate_headers.rs
+++ b/src/tests/test_accumulate_headers.rs
@@ -1,5 +1,5 @@
 use super::new_blake2b;
-use crate::{leaf_index_to_pos, util::MemStore, MMRStore, Merge, MerkleProof, Result, MMR};
+use crate::{leaf_index_to_pos, util::MemStore, MMRStoreReadOps, Merge, MerkleProof, Result, MMR};
 use bytes::{Bytes, BytesMut};
 use std::fmt;
 
@@ -106,7 +106,7 @@ impl Prover {
         let mut mmr = MMR::<_, MergeHashWithTD, _>::new(self.positions.len() as u64, &self.store);
         // get previous element
         let mut previous = if let Some(pos) = self.positions.last() {
-            MMRStore::<_>::get_elem(&&self.store, *pos)?.expect("exists")
+            MMRStoreReadOps::<_>::get_elem(&&self.store, *pos)?.expect("exists")
         } else {
             let genesis = Header::default();
 

--- a/src/tests/test_mmr.rs
+++ b/src/tests/test_mmr.rs
@@ -1,6 +1,6 @@
 use super::{MergeNumberHash, NumberHash};
 use crate::{
-    helper::pos_height_in_tree, leaf_index_to_mmr_size, util::MemStore, Error, MMRStore, MMR,
+    helper::pos_height_in_tree, leaf_index_to_mmr_size, util::MemStore, Error, MMRStoreReadOps, MMR,
 };
 use faster_hex::hex_string;
 use proptest::prelude::*;


### PR DESCRIPTION
To facilitate the implementation of different behaviors of the store, this PR splits the `MMRStore` trait into `MMRStoreReadOps` and `MMRStoreWriteOps`, for example, a readonly store implementation which only provide the mmr proof generation service may only need to impl the MMRStoreReadOps.

This PR also removed some unnecessary trait requirements from some fn.

Notes: this PR is a minor breaking change for other crates which has impl the `MMRStore` trait with old version, however, the  migration is easy, just split the old trait implementation into the new two traits.