### PR TITLE
feat: verify a old root and all incremental items after it

### DIFF
--- a/src/mmr.rs
+++ b/src/mmr.rs
@@ -320,15 +320,12 @@ impl<T: Clone + PartialEq, M: Merge<Item = T>> MerkleProof<T, M> {
         };
         let current_peaks_positions = get_peaks(self.mmr_size);
 
-        let mut reverse_index = prev_peaks_positions.len();
+        let mut reverse_index = prev_peaks_positions.len() - 1;
         for (i, position) in prev_peaks_positions.iter().enumerate() {
             if *position < current_peaks_positions[i] {
                 reverse_index = i;
                 break;
             }
-        }
-        if reverse_index == prev_peaks_positions.len() {
-            reverse_index = prev_peaks_positions.len() - 1;
         }
         let mut prev_peaks: Vec<_> = self.proof_items().to_vec();
         let mut reverse_peaks = prev_peaks.split_off(reverse_index);

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,5 +1,6 @@
 mod test_accumulate_headers;
 mod test_helper;
+mod test_incremental;
 mod test_mmr;
 mod test_sequence;
 

--- a/src/tests/test_incremental.rs
+++ b/src/tests/test_incremental.rs
@@ -1,0 +1,51 @@
+use proptest::proptest;
+
+use super::{MergeNumberHash, NumberHash};
+use crate::util::{MemMMR, MemStore};
+
+proptest! {
+    #[test]
+    fn test_incremental(start in 1u32..500, steps in 1usize..50, turns in 10usize..20) {
+        test_incremental_with_params(start, steps, turns);
+    }
+}
+
+fn test_incremental_with_params(start: u32, steps: usize, turns: usize) {
+    let store = MemStore::default();
+    let mut mmr = MemMMR::<_, MergeNumberHash>::new(0, &store);
+
+    let mut curr = 0;
+
+    let _positions: Vec<u64> = (0u32..start)
+        .map(|_| {
+            let pos = mmr.push(NumberHash::from(curr)).unwrap();
+            curr += 1;
+            pos
+        })
+        .collect();
+    mmr.commit().expect("commit changes");
+
+    for turn in 0..turns {
+        let prev_root = mmr.get_root().expect("get root");
+        let (positions, leaves) = (0..steps).fold(
+            (Vec::new(), Vec::new()),
+            |(mut positions, mut leaves), _| {
+                let leaf = NumberHash::from(curr);
+                let pos = mmr.push(leaf.clone()).unwrap();
+                curr += 1;
+                positions.push(pos);
+                leaves.push(leaf);
+                (positions, leaves)
+            },
+        );
+        mmr.commit().expect("commit changes");
+        let proof = mmr.gen_proof(positions).expect("gen proof");
+        let root = mmr.get_root().expect("get root");
+        let result = proof.verify_incremental(root, prev_root, leaves).unwrap();
+        assert!(
+            result,
+            "start: {}, steps: {}, turn: {}, curr: {}",
+            start, steps, turn, curr
+        );
+    }
+}


### PR DESCRIPTION
Add a method to verify a old root and all incremental leaves.

If this method returns `true`, it means the following assertion are true:
- The old root could be generated in the history of the current MMR.
- All incremental leaves are on the current MMR.
- The MMR, which could generate the old root, appends all incremental leaves, becomes the current MMR.

Closes #33.