### PR TITLE
chore: bump version to v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-merkle-mountain-range"
-version = "0.5.2"
+version = "0.6.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -15,12 +15,12 @@ std = []
 cfg-if = "1.0"
 
 [dev-dependencies]
-faster-hex = "0.6.1"
-criterion = "0.4.0"
+faster-hex = "0.8.0"
+criterion = "0.5.1"
 rand = "0.8.5"
-proptest = "1.0.0"
+proptest = "1.2.0"
 lazy_static = "1.4.0"
-bytes = "1.2.1"
+bytes = "1.4.0"
 blake2b-rs = "0.2.0"
 
 [[bench]]


### PR DESCRIPTION
Changes:
- chore(deps): bump all dependencies to their latest versions
- chore: bump version to v0.6.0