### PR TITLE
fix: typo in error message for invalid leaves

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ impl core::fmt::Display for Error {
             StoreError(msg) => write!(f, "Store error {}", msg)?,
             CorruptedProof => write!(f, "Corrupted proof")?,
             NodeProofsNotSupported => write!(f, "Tried to verify membership of a non-leaf")?,
-            GenProofForInvalidLeaves => write!(f, "Generate proof ofr invalid leaves")?,
+            GenProofForInvalidLeaves => write!(f, "Generate proof for invalid leaves")?,
             MergeError(msg) => write!(f, "Merge error {}", msg)?,
         }
         Ok(())


### PR DESCRIPTION
This PR corrects a typo in the error message for invalid leaves.